### PR TITLE
Saving arrays custom fields into serialize instead string type

### DIFF
--- a/custom-fields-revisions/custom-fields-revisions.php
+++ b/custom-fields-revisions/custom-fields-revisions.php
@@ -41,7 +41,7 @@ function cfr_insert_meta($post_id, $meta) {
     foreach ($meta as $meta_key => $meta_value) {
         if (is_array($meta_value))
             foreach ($meta_value as $single_meta_value)
-                add_metadata('post', $post_id, $meta_key, $single_meta_value);
+                add_metadata('post', $post_id, $meta_key, unserialize($single_meta_value));
         else
             add_metadata('post', $post_id, $meta_key, $meta_value);
     }


### PR DESCRIPTION
Hello,
My custom fileds are all PHP serialize type (array), as Wordpress array metadata by default. Because of it, i have founded a issue in your code. The `cfr_insert_meta` method was saving arrays as strings, and the `unserialize` method couldn't work after charge a revision version of the post.
To fix the issue, i have made a customization in your `cfr_insert_meta` method, see bellow:

```php
<?php
function cfr_insert_meta($post_id, $meta) {
    foreach ($meta as $meta_key => $meta_value) {
        if (is_array($meta_value))
            foreach ($meta_value as $single_meta_value)
                add_metadata('post', $post_id, $meta_key, unserialize($single_meta_value));
        else
            add_metadata('post', $post_id, $meta_key, $meta_value);
    }
}
```

I have added the `unserialize` method inside your foreach because `add_metadata` method always save array into serialize by default.

Congrats for the amazing plug-in. It made my day easier.